### PR TITLE
Optimize size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 Cargo.lock
 cargo-config.toml
 NDK/
+*.swp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,6 @@ members = ["candidateparser", "candidateparser-ffi", "candidateparser-jni"]
 
 [patch.crates-io]
 candidateparser = { path = "candidateparser" }
+
+[profile.release]
+lto = true

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,15 @@ all: android
 
 android-armv7:
 	CC=$(shell pwd)/NDK/arm/bin/arm-linux-androideabi-clang cargo build --package candidateparser-jni --release --target armv7-linux-androideabi
+	NDK/arm/arm-linux-androideabi/bin/strip target/armv7-linux-androideabi/release/libcandidateparser_jni.so
 
 android-aarch64:
 	CC=$(shell pwd)/NDK/arm64/bin/aarch64-linux-android-clang cargo build --package candidateparser-jni --release --target aarch64-linux-android
+	NDK/arm64/aarch64-linux-android/bin/strip target/aarch64-linux-android/release/libcandidateparser_jni.so
 
 android-x86:
 	CC=$(shell pwd)/NDK/x86/bin/i686-linux-android-clang cargo build --package candidateparser-jni --release --target i686-linux-android
+	NDK/x86/i686-linux-android/bin/strip target/i686-linux-android/release/libcandidateparser_jni.so
 
 android: android-armv7 android-aarch64 android-x86
 


### PR DESCRIPTION
Based on https://lifthrasiir.github.io/rustlog/why-is-a-rust-executable-large.html.

- Enable LTO: 2.2 MiB -> 1.1 MiB
- Strip debug symbols: 1.1 MiB -> 346 KiB

Fixes #1.